### PR TITLE
Add alias for street

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Uma biblioteca estupidamente simples para formatar endereços estilo google lindão, manja?
 
-### Pra que?
+## Pra que?
 
-Para transformar endereços em objeto (geralmente persistidos em algum lugar) e tranformar em uma string formatada lindona estilo Google, sabe?
+Para transformar endereços em objeto (geralmente persistidos em algum lugar) e transformar em uma string formatada lindona estilo Google, sabe?
 
 ### Instalação
 
@@ -60,37 +60,12 @@ brAddressFormatter({
 
 ### API
 
-<table>
-  <tr>
-    <th>Keyword</th>
-    <th>Alias</th>
-  </tr>
-  <tr>
-    <td>street</td>
-    <td>-</td>
-  </tr>
-  <tr>
-    <td>number</td>
-    <td>-</td>
-  </tr>
-  <tr>
-    <td>complement</td>
-    <td>-</td>
-  </tr>
-  <tr>
-    <td>neighborhood</td>
-    <td>-</td>
-  </tr>
-  <tr>
-    <td>city</td>
-    <td>-</td>
-  </tr>
-  <tr>
-    <td>state</td>
-    <td>-</td>
-  </tr>
-  <tr>
-    <td>postalCode</td>
-    <td>zipCode</td>
-  </tr>
-</table>
+| Keyword      | Alias      |
+|--------------|------------|
+| street       | streetName |
+| number       |            |
+| complement   |            |
+| neighborhood |            |
+| city         |            |
+| state        |            |
+| postalCode   | zipCode    |

--- a/lib/sanitizer.js
+++ b/lib/sanitizer.js
@@ -1,7 +1,7 @@
 class Sanitizer {
   constructor () {
     this.keywords = {
-      street: [],
+      street: ['streetName'],
       number: [],
       complement: [],
       neighborhood: [],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "br-address-formatter",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/lib.spec.js
+++ b/test/lib.spec.js
@@ -79,6 +79,19 @@ test('given address object with postalCode, street, city, state, neighborhood, n
   expect.is(formattedAddress, 'Rua dos Pinheiros, 383 - Ed. Alamac AP 133 - Pinheiros, São Paulo - SP, 15085-480')
 })
 
+test('given address object with postalCode, streetName, city, state, neighborhood, number and complement address string should as expected', expect => {
+  const formattedAddress = brAddressFormatter({
+    postalCode: '15085480',
+    streetName: 'Rua dos Pinheiros',
+    city: 'São Paulo',
+    state: 'SP',
+    neighborhood: 'Pinheiros',
+    complement: 'Ed. Alamac AP 133',
+    number: '383'
+  })
+  expect.is(formattedAddress, 'Rua dos Pinheiros, 383 - Ed. Alamac AP 133 - Pinheiros, São Paulo - SP, 15085-480')
+})
+
 test('given address object with postalCode in Mexican format should format as expected', expect => {
   const formattedAddress = brAddressFormatter({
     postalCode: '06010',

--- a/test/sanitizer.spec.js
+++ b/test/sanitizer.spec.js
@@ -72,9 +72,31 @@ test('given address with correct and incorrect keywords should be sanitized', ex
   })
 })
 
-test('given address with correct and alias keywords should be sanitized', expect => {
+test('given address with correct and alias for postalCode keyword should be sanitized', expect => {
   const address = sanitizer.sanitize({
     street: 'Rua teste',
+    number: 'Numero teste',
+    complement: 'Complemento teste',
+    neighborhood: 'Bairro teste',
+    city: 'Cidade teste',
+    state: 'Estado teste',
+    zipCode: 'CEP teste'
+  })
+
+  expect.deepEqual(address, {
+    street: 'Rua teste',
+    number: 'Numero teste',
+    complement: 'Complemento teste',
+    neighborhood: 'Bairro teste',
+    city: 'Cidade teste',
+    state: 'Estado teste',
+    postalCode: 'CEP teste'
+  })
+})
+
+test('given address with correct and alias for street keyword should be sanitized', expect => {
+  const address = sanitizer.sanitize({
+    streetName: 'Rua teste',
     number: 'Numero teste',
     complement: 'Complemento teste',
     neighborhood: 'Bairro teste',


### PR DESCRIPTION
This pr add add streetName  alias for street property.

The idea is to take advantage of the alias support that the lib provides to avoid mapping objects where this lib is used.

Tests and docs are updated too